### PR TITLE
Validation [PoC]

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "js/vendor/parsley"]
+	path = js/vendor/parsley
+	url = https://github.com/guillaumepotier/Parsley.js.git

--- a/classes.fields.php
+++ b/classes.fields.php
@@ -228,7 +228,7 @@ abstract class CMB_Field {
 		$this->validation_rules = $this->args['validation'];
 
 		add_action( 'post_edit_form_tag', function () {
-			echo esc_attr( ' data-parsley-validate ' );
+			echo esc_attr( ' data-cmb-validate ' );
 		});
 	}
 

--- a/classes.fields.php
+++ b/classes.fields.php
@@ -268,15 +268,21 @@ abstract class CMB_Field {
 			return '';
 		}
 
-		$validation_rules = array_filter( array_unique( wp_parse_args( $attrs, $this->args['validation'] ) ) );
+		$validation_rules = wp_parse_args( $attrs, $this->args['validation'] );
 
-		// Validation rule: Required.
-		if ( in_array( 'required', $validation_rules, true ) ) {
-			echo esc_attr( ' required ' );
-			unset( $validation_rules['required'] ); // Remove now for future attributes.
+		foreach ( $validation_rules as $attr => $value ) {
+			if ( 'required' === $attr && $attr ) {
+				echo ' data-parsley-required ';
+			} else {
+				if ( is_bool( $value ) ) {
+					printf( ' data-parsley-type="%s" ', esc_attr( $attr ) );
+				} else {
+					printf( ' data-parsley-%s="%s" ', esc_attr( $attr ), esc_attr( $value ) );
+				}
+			}
 		}
-
 	}
+
 
 	/**
 	 * Check if this field has a data delegate set

--- a/js/cmb.js
+++ b/js/cmb.js
@@ -316,7 +316,7 @@ var CMB = {
 
 		var postFormSelector = jQuery('#post');
 
-		if ( typeof postFormSelector.attr('data-parsley-validate') !== 'undefined' ) {
+		if ( typeof postFormSelector.attr('data-cmb-validate') !== 'undefined' ) {
 			postFormSelector.parsley();
 		}
 

--- a/js/cmb.js
+++ b/js/cmb.js
@@ -30,6 +30,8 @@ var CMB = {
 		// When toggling the display of the meta box container - reinitialize
 		jQuery(document).on( 'click.CMB', '.postbox h3, .postbox .handlediv', CMB.init );
 
+		CMB.containsValidation();
+
 		CMB.doneInit();
 
 		jQuery('.field.cmb-sortable' ).each( function() {
@@ -303,6 +305,20 @@ var CMB = {
 
 		this._sortEndCallbacks[fieldName] = this._sortEndCallbacks[fieldName] ? this._sortEndCallbacks[fieldName] : []
 		this._sortEndCallbacks[fieldName].push( callback )
+
+	},
+
+	/**
+	 * Checks whether form # contains validation data attributes
+	 * and instantiate validation library (parsley.js).
+	 */
+	containsValidation: function() {
+
+		var postFormSelector = jQuery('#post');
+
+		if ( typeof postFormSelector.attr('data-parsley-validate') !== 'undefined' ) {
+			postFormSelector.parsley();
+		}
 
 	}
 

--- a/tests/testValidation.php
+++ b/tests/testValidation.php
@@ -32,7 +32,6 @@ class FieldValidationTestCase extends WP_UnitTestCase {
 
 		$field = new CMB_Text_Field( 'foo', 'Text', array( 1, 2 ), array( 'validation' => array( 'required' ) ) );
 
-		// Required attr set
 		$required_attr = $field->has_validation_rule( 'required' );
 
 		$this->assertTrue( $required_attr );
@@ -47,18 +46,81 @@ class FieldValidationTestCase extends WP_UnitTestCase {
 
 	}
 
-	function testFieldHasRequiredAttr() {
+	function testFieldHasRequiredValidationAttr() {
 
-		$field = new CMB_Text_Field( 'foo', 'Text', array( 1 ), array( 'validation' => array( 'required' ) ) );
+		$field = new CMB_Text_Field( 'foo', 'Text', array( 1 ), array( 'validation' => array( 'required' => true ) ) );
 
-		ob_start();
-		$required_attr = $field->validation_attr();
-		$required_attr = ob_get_contents();
-		ob_end_clean();
+		$validation_attr = $this->getValidationAttributeOutput( $field );
 
-		$this->assertSame( $required_attr, ' required ' );
+		$this->assertContains( 'data-parsley-required' , $validation_attr );
 	}
 
-	function testParsleyIsLoaded() {}
+	function testFieldHasEmailValidationAttr() {
 
+		$field = new CMB_Text_Field( 'foo', 'Text', array( 1 ), array( 'validation' => array( 'required' => true, 'email' => true ) ) );
+
+		$validation_attr = $this->getValidationAttributeOutput( $field );
+
+		$this->assertContains( 'data-parsley-type="email"', $validation_attr );
+	}
+
+	function testFieldHasMinLengthValidationAttr() {
+
+		$field = new CMB_Text_Field( 'foo', 'Text', array( 1 ), array( 'validation' => array( 'minlength' => 1 ) ) );
+
+		$validation_attr = $this->getValidationAttributeOutput( $field );
+
+		$this->assertContains( 'data-parsley-minlength="1"', $validation_attr );
+	}
+
+	function testFieldHasMaxLengthValidationAttr() {
+
+		$field = new CMB_Text_Field( 'foo', 'Text', array( 1 ), array( 'validation' => array( 'maxlength' => 1 ) ) );
+
+		$validation_attr = $this->getValidationAttributeOutput( $field );
+
+		$this->assertContains( 'data-parsley-maxlength="1"', $validation_attr );
+	}
+
+	function testFieldHasMaxLengthAndMaxLengthValidationAttr() {
+
+		$field = new CMB_Text_Field( 'foo', 'Text', array( 1 ), array( 'validation' => array( 'maxlength' => 1, 'minlength' => 1 ) ) );
+
+		$validation_attr = $this->getValidationAttributeOutput( $field );
+
+		$this->assertContains( 'data-parsley-maxlength="1"  data-parsley-minlength="1"', $validation_attr );
+	}
+
+	function testFieldHasMinValidationAttr() {
+
+		$field = new CMB_Text_Field( 'foo', 'Text', array( 1 ), array( 'validation' => array( 'min' => 1 ) ) );
+
+		$validation_attr = $this->getValidationAttributeOutput( $field );
+
+		$this->assertContains( 'data-parsley-min="1"', $validation_attr );
+	}
+
+	function testFieldHasMaxValidationAttr() {
+
+		$field = new CMB_Text_Field( 'foo', 'Text', array( 1 ), array( 'validation' => array( 'max' => 1 ) ) );
+
+		$validation_attr = $this->getValidationAttributeOutput( $field );
+
+		$this->assertContains( 'data-parsley-max="1"', $validation_attr );
+	}
+
+	/**
+	 * @param $field CMB_Field
+	 *
+	 * @return string html attribute string used for validation of the passed field.
+	 */
+	function getValidationAttributeOutput( $field ) {
+
+		ob_start();
+		$field->validation_attr();
+		$attr_output = ob_get_contents();
+		ob_end_clean();
+
+		return $attr_output;
+	}
 }

--- a/tests/testValidation.php
+++ b/tests/testValidation.php
@@ -1,0 +1,64 @@
+<?php
+
+class FieldValidationTestCase extends WP_UnitTestCase {
+
+	private $post;
+
+	function setUp() {
+
+		parent::setUp();
+
+		$args = array(
+			'post_author'  => 1,
+			'post_status'  => 'publish',
+			'post_content' => rand_str(),
+			'post_title'   => rand_str(),
+			'post_type'    => 'post',
+		);
+
+		$id = wp_insert_post( $args );
+
+		$this->post = get_post( $id );
+
+	}
+
+	function tearDown() {
+		wp_delete_post( $this->post->ID, true );
+		unset( $this->post );
+		parent::tearDown();
+	}
+
+	function testFieldContainsValidationRule() {
+
+		$field = new CMB_Text_Field( 'foo', 'Text', array( 1, 2 ), array( 'validation' => array( 'required' ) ) );
+
+		// Required attr set
+		$required_attr = $field->has_validation_rule( 'required' );
+
+		$this->assertTrue( $required_attr );
+
+	}
+
+	function testFieldHasValidation() {
+
+		$field = new CMB_Text_Field( 'foo', 'Text', array( 1, 2 ), array( 'validation' => array( 'required' ) ) );
+
+		$this->assertTrue( $field->requires_validation() );
+
+	}
+
+	function testFieldHasRequiredAttr() {
+
+		$field = new CMB_Text_Field( 'foo', 'Text', array( 1 ), array( 'validation' => array( 'required' ) ) );
+
+		ob_start();
+		$required_attr = $field->validation_attr();
+		$required_attr = ob_get_contents();
+		ob_end_clean();
+
+		$this->assertSame( $required_attr, ' required ' );
+	}
+
+	function testParsleyIsLoaded() {}
+
+}


### PR DESCRIPTION
PO to address adding some front-end JS validation to our CMB.

**Must Haves**
- Support [Built-in validators](http://parsleyjs.org/doc/index.html#psly-validators-list) **excluding regex**
- Some CSS, but #opinions
- Document usage
- Test
- Test CMB columns support (4/4/4, 3/6/3 etc)

**Nice to haves**
- Support regex validation
- Support messages for failed, valid fields
- Extendable CSS for #opinions 
- WTF are http://parsleyjs.org/doc/index.html#extras? Should these be supported
- Possible fields anywhere support

**Pics or ...**
![](http://caught-by-tarei.s3.amazonaws.com/6pMd8Xzd.gif)
